### PR TITLE
docs: 更新友情链接以丰富资源

### DIFF
--- a/page/links.md
+++ b/page/links.md
@@ -46,6 +46,8 @@ image: "https://webp.debuginn.com/20250221QKKCYH.jpeg"
 
 ## 博客组织
 
+[BlogsClub](https://www.blogsclub.org/blog/291.html)
+ | 
 [BlogFinder](https://bf.zzxworld.com/s/870)
  | 
 [十年之约](https://www.foreverblog.cn/)
@@ -55,6 +57,8 @@ image: "https://webp.debuginn.com/20250221QKKCYH.jpeg"
 [博客录](https://boke.lu/)
  | 
 [博友圈](https://www.boyouquan.com/blogs/blog.debuginn.com)
+ | 
+[笔墨迹](https://blogscn.fun/)
 
 ![friend](https://webp.debuginn.com/20250607PVNEDF.png)
 


### PR DESCRIPTION
- 添加了新的博客组织链接，包括BlogsClub和笔墨迹，以增强页面内容的多样性和可访问性。