### PR TITLE
docs: 更新旅行博文的分类标签

### DIFF
--- a/post/travel-bohainan.md
+++ b/post/travel-bohainan.md
@@ -4,7 +4,7 @@ date: 2025-05-10T22:00:00+08:00
 keywords: "travel"
 comments: true
 tags: ["travel"]
-categories: ["debuginn"]
+categories: ["travel"]
 image: "https://static.debuginn.com/2025051038jxzl.jpg"
 ---
 


### PR DESCRIPTION
- 将旅行博文的分类从“debuginn”更改为“travel”，以更准确地反映内容主题。